### PR TITLE
Feature: Add options to copy sorted file names as text

### DIFF
--- a/src/Flow.Launcher.Plugin.ClipboardPlus.Core/Data/Enums/DefaultCopyOption.cs
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus.Core/Data/Enums/DefaultCopyOption.cs
@@ -9,7 +9,7 @@ public enum DefaultRichTextCopyOption
     Rtf = 0,
 
     [EnumLocalizeKey(nameof(Localize.flowlauncher_plugin_clipboardplus_copy_plain_text_title))]
-    Plain = 1
+    Plain = 1,
 }
 
 [EnumLocalize]
@@ -19,7 +19,7 @@ public enum DefaultImageCopyOption
     Image = 0,
 
     [EnumLocalizeKey(nameof(Localize.flowlauncher_plugin_clipboardplus_copy_image_file_title))]
-    File = 1
+    File = 1,
 }
 
 [EnumLocalize]
@@ -28,15 +28,21 @@ public enum DefaultFilesCopyOption
     [EnumLocalizeKey(nameof(Localize.flowlauncher_plugin_clipboardplus_copy_files_title))]
     Files = 0,
 
+    [EnumLocalizeKey(nameof(Localize.flowlauncher_plugin_clipboardplus_copy_file_path_title))]
+    Path = 3,
+
+    [EnumLocalizeKey(nameof(Localize.flowlauncher_plugin_clipboardplus_copy_file_content_title))]
+    Content = 4,
+
     [EnumLocalizeKey(nameof(Localize.flowlauncher_plugin_clipboardplus_copy_sort_name_asc_title))]
     NameAsc = 1,
 
     [EnumLocalizeKey(nameof(Localize.flowlauncher_plugin_clipboardplus_copy_sort_name_desc_title))]
     NameDesc = 2,
 
-    [EnumLocalizeKey(nameof(Localize.flowlauncher_plugin_clipboardplus_copy_file_path_title))]
-    Path = 3,
+    [EnumLocalizeKey(nameof(Localize.flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_title))]
+    FileNameTextAsc = 5,
 
-    [EnumLocalizeKey(nameof(Localize.flowlauncher_plugin_clipboardplus_copy_file_content_title))]
-    Content = 4
+    [EnumLocalizeKey(nameof(Localize.flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_title))]
+    FileNameTextDesc = 6,
 }

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/en.xaml
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/en.xaml
@@ -66,6 +66,10 @@
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_asc_subtitle">Copy this record as files by sorting file paths ascendingly</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_title">Copy as files by descen paths</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_subtitle">Copy this record as files by sorting file paths descendingly</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_title">Copy file names as text by ascending paths</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_subtitle">Sort by full path in ascending order, then copy newline-separated file names without directories</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_title">Copy file names as text by descending paths</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_subtitle">Sort by full path in descending order, then copy newline-separated file names without directories</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_title">Copy as file path</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_subtitle">Copy this record as file path</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_content_title">Copy as file content</system:String>

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/fr.xaml
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/fr.xaml
@@ -66,6 +66,10 @@
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_asc_subtitle">Copie cette entrée en tant que fichiers en triant les chemins des fichiers par ordre croissant.</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_title">Copier en tant que fichiers par chemins décroissants</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_subtitle">Copie cette entrée en tant que fichiers en triant les chemins des fichiers par ordre décroissant.</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_title">Copier les noms de fichiers comme texte par chemins croissants</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_subtitle">Trie les chemins complets par ordre croissant, puis copie uniquement les noms de fichiers séparés par des sauts de ligne.</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_title">Copier les noms de fichiers comme texte par chemins décroissants</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_subtitle">Trie les chemins complets par ordre décroissant, puis copie uniquement les noms de fichiers séparés par des sauts de ligne.</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_title">Copier en tant que chemin de fichier</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_subtitle">Copie cette entrée en tant que chemin de fichier.</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_content_title">Copier en tant que contenu de fichier</system:String>

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/zh-cn.xaml
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/zh-cn.xaml
@@ -66,6 +66,10 @@
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_asc_subtitle">以文件路径上升排序的方式复制为文件</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_title">以路径下降方式复制为文件</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_subtitle">以文件路径下降排序的方式复制为文件</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_title">以路径上升方式复制为文件名字符串</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_subtitle">按完整路径上升排序后，以换行分隔复制不含目录的文件名</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_title">以路径下降方式复制为文件名字符串</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_subtitle">按完整路径下降排序后，以换行分隔复制不含目录的文件名</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_title">复制为文件路径</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_subtitle">复制记录为文件路径</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_content_title">复制为文件内容</system:String>

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/zh-tw.xaml
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/zh-tw.xaml
@@ -66,6 +66,10 @@
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_asc_subtitle">以文件路徑上升排序的方式複製為文件</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_title">以路徑下降方式複製為文件</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_subtitle">以文件路徑下降排序的方式複製為文件</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_title">以路徑上升方式複製為文件名字符串</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_subtitle">按完整路徑上升排序後，以換行分隔複製不含目錄的文件名</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_title">以路徑下降方式複製為文件名字符串</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_subtitle">按完整路徑下降排序後，以換行分隔複製不含目錄的文件名</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_title">複製為文件路徑</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_subtitle">複製記録為文件路徑</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_content_title">複製為文件內容</system:String>

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
@@ -721,53 +721,23 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                 );
                 break;
             case DataType.Files:
-                results.AddRange(
-                    [
-                        new Result
-                        {
-                            Title = Localize.flowlauncher_plugin_clipboardplus_copy_files_title(),
-                            SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_files_subtitle(),
-                            IcoPath = PathHelper.CopyIconPath,
-                            Glyph = ResourceHelper.CopyGlyph,
-                            Score = ScoreInterval8,
-                            AddSelectedCount = false,
-                            Action = (c) =>
-                            {
-                                CopyOriginallyToClipboard(clipboardDataPair);
-                                return true;
-                            }
-                        },
-                        new Result
-                        {
-                            Title = Localize.flowlauncher_plugin_clipboardplus_copy_sort_name_asc_title(),
-                            SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_sort_name_asc_subtitle(),
-                            IcoPath = PathHelper.CopyIconPath,
-                            Glyph = ResourceHelper.CopyGlyph,
-                            Score = ScoreInterval7,
-                            AddSelectedCount = false,
-                            Action = (c) =>
-                            {
-                                CopyBySortingNameToClipboard(clipboardDataPair, true);
-                                return true;
-                            }
-                        },
-                        new Result
-                        {
-                            Title = Localize.flowlauncher_plugin_clipboardplus_copy_sort_name_desc_title(),
-                            SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_sort_name_desc_subtitle(),
-                            IcoPath = PathHelper.CopyIconPath,
-                            Glyph = ResourceHelper.CopyGlyph,
-                            Score = ScoreInterval6,
-                            AddSelectedCount = false,
-                            Action = (c) =>
-                            {
-                                CopyBySortingNameToClipboard(clipboardDataPair, false);
-                                return true;
-                            }
-                        }
-                    ]
-                );
+                // Copy as files
+                results.Add(new Result
+                {
+                    Title = Localize.flowlauncher_plugin_clipboardplus_copy_files_title(),
+                    SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_files_subtitle(),
+                    IcoPath = PathHelper.CopyIconPath,
+                    Glyph = ResourceHelper.CopyGlyph,
+                    Score = ScoreInterval8,
+                    AddSelectedCount = false,
+                    Action = (c) =>
+                    {
+                        CopyOriginallyToClipboard(clipboardDataPair);
+                        return true;
+                    }
+                });
 
+                // Copy file path or content
                 var validObject = clipboardData.DataToValid();
                 if (validObject is string[] filePaths && filePaths.Length == 1)
                 {
@@ -779,7 +749,7 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                             SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_file_path_subtitle(),
                             IcoPath = PathHelper.CopyIconPath,
                             Glyph = ResourceHelper.CopyGlyph,
-                            Score = ScoreInterval5,
+                            Score = ScoreInterval7,
                             AddSelectedCount = false,
                             Action = (c) =>
                             {
@@ -793,7 +763,7 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                             SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_file_content_subtitle(),
                             IcoPath = PathHelper.CopyIconPath,
                             Glyph = ResourceHelper.CopyGlyph,
-                            Score = ScoreInterval4,
+                            Score = ScoreInterval6,
                             AddSelectedCount = false,
                             Action = (c) =>
                             {
@@ -803,6 +773,68 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                         }
                     ]);
                 }
+
+                // Copy file by sorting paths
+                results.AddRange(
+                    [
+                        new Result
+                        {
+                            Title = Localize.flowlauncher_plugin_clipboardplus_copy_sort_name_asc_title(),
+                            SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_sort_name_asc_subtitle(),
+                            IcoPath = PathHelper.CopyIconPath,
+                            Glyph = ResourceHelper.CopyGlyph,
+                            Score = ScoreInterval5,
+                            AddSelectedCount = false,
+                            Action = (c) =>
+                            {
+                                CopyBySortingNameToClipboard(clipboardDataPair, true);
+                                return true;
+                            }
+                        },
+                        new Result
+                        {
+                            Title = Localize.flowlauncher_plugin_clipboardplus_copy_sort_name_desc_title(),
+                            SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_sort_name_desc_subtitle(),
+                            IcoPath = PathHelper.CopyIconPath,
+                            Glyph = ResourceHelper.CopyGlyph,
+                            Score = ScoreInterval4,
+                            AddSelectedCount = false,
+                            Action = (c) =>
+                            {
+                                CopyBySortingNameToClipboard(clipboardDataPair, false);
+                                return true;
+                            }
+                        },
+                        new Result
+                        {
+                            Title = Localize.flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_title(),
+                            SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_subtitle(),
+                            IcoPath = PathHelper.CopyIconPath,
+                            Glyph = ResourceHelper.CopyGlyph,
+                            Score = ScoreInterval3,
+                            AddSelectedCount = false,
+                            Action = (c) =>
+                            {
+                                CopyFileNamesBySortingPathToClipboard(clipboardDataPair, true);
+                                return true;
+                            }
+                        },
+                        new Result
+                        {
+                            Title = Localize.flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_title(),
+                            SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_subtitle(),
+                            IcoPath = PathHelper.CopyIconPath,
+                            Glyph = ResourceHelper.CopyGlyph,
+                            Score = ScoreInterval2,
+                            AddSelectedCount = false,
+                            Action = (c) =>
+                            {
+                                CopyFileNamesBySortingPathToClipboard(clipboardDataPair, false);
+                                return true;
+                            }
+                        }
+                    ]
+                );
                 break;
             default:
                 break;
@@ -1752,6 +1784,12 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                     case DefaultFilesCopyOption.NameDesc:
                         CopyBySortingNameToClipboard(clipboardDataPair, false);
                         break;
+                    case DefaultFilesCopyOption.FileNameTextAsc:
+                        CopyFileNamesBySortingPathToClipboard(clipboardDataPair, true);
+                        break;
+                    case DefaultFilesCopyOption.FileNameTextDesc:
+                        CopyFileNamesBySortingPathToClipboard(clipboardDataPair, false);
+                        break;
                     case DefaultFilesCopyOption.Path:
                         var validObject = clipboardData.DataToValid();
                         var filePaths = (validObject as string[])!;
@@ -2004,6 +2042,42 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
     private static string[] SortDescending(string[] strings)
     {
         return [.. strings.OrderByDescending(path => path, new NaturalStringComparer())];
+    }
+
+    private async void CopyFileNamesBySortingPathToClipboard(ClipboardDataPair clipboardDataPair, bool ascend)
+    {
+        var clipboardData = clipboardDataPair.ClipboardData;
+        if (clipboardData.DataType != DataType.Files)
+        {
+            return;
+        }
+
+        if (clipboardData.DataToValid() is not string[] validFilePaths)
+        {
+            Context.ShowMsgError(Localize.flowlauncher_plugin_clipboardplus_fail(),
+                Localize.flowlauncher_plugin_clipboardplus_files_data_invalid());
+            return;
+        }
+
+        var sortedFilePaths = ascend ? SortAscending(validFilePaths) : SortDescending(validFilePaths);
+        var fileNames = sortedFilePaths.Select(Path.GetFileName);
+        var text = string.Join(Environment.NewLine, fileNames);
+        var exception = await RetryActionOnSTAThreadAsync(() => Clipboard.SetText(text));
+        if (exception == null)
+        {
+            if (Settings.ShowNotification)
+            {
+                Context.ShowMsg(Localize.flowlauncher_plugin_clipboardplus_success(),
+                    Localize.flowlauncher_plugin_clipboardplus_copy_to_clipboard() +
+                    StringUtils.CompressString(text, StringMaxLength));
+            }
+        }
+        else
+        {
+            Context.LogException(ClassName, "Copy file names as text to clipboard failed", exception);
+            Context.ShowMsgError(Localize.flowlauncher_plugin_clipboardplus_fail(),
+                Localize.flowlauncher_plugin_clipboardplus_copy_to_clipboard_exception());
+        }
     }
 
     public class NaturalStringComparer : IComparer<string>

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
@@ -2060,7 +2060,9 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
         }
 
         var sortedFilePaths = ascend ? SortAscending(validFilePaths) : SortDescending(validFilePaths);
-        var fileNames = sortedFilePaths.Select(Path.GetFileName);
+        var fileNames = sortedFilePaths
+            .Select(p => Path.GetFileName(Path.TrimEndingDirectorySeparator(p)))
+            .Where(name => !string.IsNullOrEmpty(name));
         var text = string.Join(Environment.NewLine, fileNames);
         var exception = await RetryActionOnSTAThreadAsync(() => Clipboard.SetText(text));
         if (exception == null)


### PR DESCRIPTION
New options allow copying file names sorted by path (asc/desc) to the clipboard. Updated DefaultFilesCopyOption enum and localized strings. Context menu and logic modified to support these options. Implemented sorting and copying method. Adjusted ordering of existing copy options.