### PR TITLE
Simplify action titles in localization files

### DIFF
--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/en.xaml
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/en.xaml
@@ -66,9 +66,9 @@
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_asc_subtitle">Copy this record as files by sorting file paths ascendingly</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_title">Copy as files by descen paths</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_subtitle">Copy this record as files by sorting file paths descendingly</system:String>
-    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_title">Copy file names as text by ascending paths</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_title">Copy file names by ascending paths</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_subtitle">Sort by full path in ascending order, then copy newline-separated file names without directories</system:String>
-    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_title">Copy file names as text by descending paths</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_title">Copy file names by descending paths</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_subtitle">Sort by full path in descending order, then copy newline-separated file names without directories</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_title">Copy as file path</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_subtitle">Copy this record as file path</system:String>

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/fr.xaml
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/fr.xaml
@@ -66,9 +66,9 @@
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_asc_subtitle">Copie cette entrée en tant que fichiers en triant les chemins des fichiers par ordre croissant.</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_title">Copier en tant que fichiers par chemins décroissants</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_subtitle">Copie cette entrée en tant que fichiers en triant les chemins des fichiers par ordre décroissant.</system:String>
-    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_title">Copier les noms de fichiers comme texte par chemins croissants</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_title">Copier les noms de fichiers par chemins croissants</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_subtitle">Trie les chemins complets par ordre croissant, puis copie uniquement les noms de fichiers séparés par des sauts de ligne.</system:String>
-    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_title">Copier les noms de fichiers comme texte par chemins décroissants</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_title">Copier les noms de fichiers par chemins décroissants</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_subtitle">Trie les chemins complets par ordre décroissant, puis copie uniquement les noms de fichiers séparés par des sauts de ligne.</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_title">Copier en tant que chemin de fichier</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_subtitle">Copie cette entrée en tant que chemin de fichier.</system:String>

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/zh-cn.xaml
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/zh-cn.xaml
@@ -66,9 +66,9 @@
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_asc_subtitle">以文件路径上升排序的方式复制为文件</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_title">以路径下降方式复制为文件</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_subtitle">以文件路径下降排序的方式复制为文件</system:String>
-    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_title">以路径上升方式复制为文件名字符串</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_title">以路径上升方式复制为文件名</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_subtitle">按完整路径上升排序后，以换行分隔复制不含目录的文件名</system:String>
-    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_title">以路径下降方式复制为文件名字符串</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_title">以路径下降方式复制为文件名</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_subtitle">按完整路径下降排序后，以换行分隔复制不含目录的文件名</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_title">复制为文件路径</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_subtitle">复制记录为文件路径</system:String>

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/zh-tw.xaml
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/zh-tw.xaml
@@ -66,9 +66,9 @@
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_asc_subtitle">以文件路徑上升排序的方式複製為文件</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_title">以路徑下降方式複製為文件</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_name_desc_subtitle">以文件路徑下降排序的方式複製為文件</system:String>
-    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_title">以路徑上升方式複製為文件名字符串</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_title">以路徑上升方式複製為文件名</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_asc_as_text_subtitle">按完整路徑上升排序後，以換行分隔複製不含目錄的文件名</system:String>
-    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_title">以路徑下降方式複製為文件名字符串</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_title">以路徑下降方式複製為文件名</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_text_subtitle">按完整路徑下降排序後，以換行分隔複製不含目錄的文件名</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_title">複製為文件路徑</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_subtitle">複製記録為文件路徑</system:String>


### PR DESCRIPTION
The action titles "Copy file names as text by ascending/descending paths" were simplified to "Copy file names by ascending/descending paths" in all localization files (en, fr, zh-cn, zh-tw). Wording was adjusted for clarity and consistency. No other keys or subtitles were changed.