### PR TITLE
Feature: Add "Copy as file name" option to context menu

### DIFF
--- a/src/Flow.Launcher.Plugin.ClipboardPlus.Core.Test/UtilsTest.cs
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus.Core.Test/UtilsTest.cs
@@ -67,6 +67,16 @@ public class UtilsTest
     }
 
     [Theory]
+    [InlineData(@"C:\", "C:")]
+    [InlineData(@"\\server\share\", "share")]
+    [InlineData(@"C:\folder\", "folder")]
+    [InlineData(@"C:\folder\file.txt", "file.txt")]
+    public void TestGetPathName(string path, string expected)
+    {
+        Assert.Equal(expected, FileUtils.GetPathName(path));
+    }
+
+    [Theory]
     [InlineData("Test")]
     [InlineData("你好")]
     [InlineData("📌")]

--- a/src/Flow.Launcher.Plugin.ClipboardPlus.Core/Data/Enums/DefaultCopyOption.cs
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus.Core/Data/Enums/DefaultCopyOption.cs
@@ -31,6 +31,9 @@ public enum DefaultFilesCopyOption
     [EnumLocalizeKey(nameof(Localize.flowlauncher_plugin_clipboardplus_copy_file_path_title))]
     Path = 3,
 
+    [EnumLocalizeKey(nameof(Localize.flowlauncher_plugin_clipboardplus_copy_file_name_title))]
+    FileName = 9,
+
     [EnumLocalizeKey(nameof(Localize.flowlauncher_plugin_clipboardplus_copy_file_content_title))]
     Content = 4,
 

--- a/src/Flow.Launcher.Plugin.ClipboardPlus.Core/Data/Models/Clipboard/ClipboardData.cs
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus.Core/Data/Models/Clipboard/ClipboardData.cs
@@ -258,7 +258,7 @@ public partial struct ClipboardData : IEquatable<ClipboardData>, IDisposable
     /// <returns>
     /// If data type is Text, return the data as valid string.
     /// If data type is Image, return the data as BitmapSource.
-    /// If data type is Files, return the data as string[].
+    /// If data type is Files, return the data as string[] with valid files.
     /// Else return null.
     /// </returns>
     public readonly object? DataToValid()
@@ -290,7 +290,12 @@ public partial struct ClipboardData : IEquatable<ClipboardData>, IDisposable
                 {
                     break;
                 }
-                return filesToCopy;
+                var validFiles = filesToCopy.Where(FileUtils.Exists).ToArray();
+                if (validFiles.Length == 0)
+                {
+                    break;
+                }
+                return validFiles;
             default:
                 break;
         }

--- a/src/Flow.Launcher.Plugin.ClipboardPlus.Core/Data/Models/Clipboard/ClipboardData.cs
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus.Core/Data/Models/Clipboard/ClipboardData.cs
@@ -258,7 +258,7 @@ public partial struct ClipboardData : IEquatable<ClipboardData>, IDisposable
     /// <returns>
     /// If data type is Text, return the data as valid string.
     /// If data type is Image, return the data as BitmapSource.
-    /// If data type is Files, return the data as string[] with valid files.
+    /// If data type is Files, return the data as string[].
     /// Else return null.
     /// </returns>
     public readonly object? DataToValid()
@@ -290,12 +290,7 @@ public partial struct ClipboardData : IEquatable<ClipboardData>, IDisposable
                 {
                     break;
                 }
-                var validFiles = filesToCopy.Where(FileUtils.Exists).ToArray();
-                if (validFiles.Length == 0)
-                {
-                    break;
-                }
-                return validFiles;
+                return filesToCopy;
             default:
                 break;
         }

--- a/src/Flow.Launcher.Plugin.ClipboardPlus.Core/Utils/FileUtils.cs
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus.Core/Utils/FileUtils.cs
@@ -7,6 +7,32 @@ namespace Flow.Launcher.Plugin.ClipboardPlus.Core.Utils;
 
 public static class FileUtils
 {
+    public static string GetPathName(string path)
+    {
+        var trimmedPath = Path.TrimEndingDirectorySeparator(path);
+        var name = Path.GetFileName(trimmedPath);
+        if (!string.IsNullOrEmpty(name))
+        {
+            return name;
+        }
+
+        var root = Path.GetPathRoot(path);
+        if (string.IsNullOrEmpty(root))
+        {
+            return trimmedPath;
+        }
+
+        var trimmedRoot = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (string.IsNullOrEmpty(trimmedRoot))
+        {
+            return root;
+        }
+
+        var separatorIndex = trimmedRoot.LastIndexOfAny([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar]);
+        var rootLabel = trimmedRoot[(separatorIndex + 1)..];
+        return string.IsNullOrEmpty(rootLabel) ? trimmedRoot : rootLabel;
+    }
+
     public static string SaveImageCache(ClipboardData clipboardData, string imageCachePath, string name)
     {
         if (clipboardData.Data is not BitmapSource img)

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/en.xaml
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/en.xaml
@@ -76,6 +76,8 @@
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_path_subtitle">Sort by full path in descending order, then copy newline-separated full file paths</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_title">Copy as file path</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_subtitle">Copy this record as file path</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_name_title">Copy as file name</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_name_subtitle">Copy file names without directories, separated by newlines</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_content_title">Copy as file content</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_content_subtitle">Copy this record as file content</system:String>
 

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/fr.xaml
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/fr.xaml
@@ -76,6 +76,8 @@
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_path_subtitle">Trie les chemins d’accès complets des fichiers par ordre décroissant, puis les copie en les séparant par des sauts de ligne.</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_title">Copier en tant que chemin de fichier</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_subtitle">Copie cette entrée en tant que chemin de fichier.</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_name_title">Copier en tant que nom de fichier</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_name_subtitle">Copie les noms de fichiers sans les dossiers, séparés par des sauts de ligne.</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_content_title">Copier en tant que contenu de fichier</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_content_subtitle">Copie cette entrée en tant que contenu de fichier.</system:String>
 

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/zh-cn.xaml
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/zh-cn.xaml
@@ -76,6 +76,8 @@
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_path_subtitle">按完整路径下降排序后，以换行分隔复制完整文件路径</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_title">复制为文件路径</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_subtitle">复制记录为文件路径</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_name_title">复制为文件名</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_name_subtitle">复制不含目录的文件名，多个文件名以换行分隔</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_content_title">复制为文件内容</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_content_subtitle">复制记录为文件内容</system:String>
 

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/zh-tw.xaml
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Languages/zh-tw.xaml
@@ -76,6 +76,8 @@
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_sort_path_desc_as_path_subtitle">按完整路徑下降排序後，以換行分隔複製完整檔案路徑</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_title">複製為文件路徑</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_path_subtitle">複製記録為文件路徑</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_name_title">複製為文件名</system:String>
+    <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_name_subtitle">複製不含目錄的文件名，多個文件名以換行分隔</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_content_title">複製為文件內容</system:String>
     <system:String x:Key="flowlauncher_plugin_clipboardplus_copy_file_content_subtitle">複製記録為文件內容</system:String>
 

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
@@ -745,6 +745,8 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                 var validObject = clipboardData.DataToValid();
                 if (validObject is string[] filePaths)
                 {
+                    var existingFilePaths = filePaths.Where(FileUtils.Exists).ToArray();
+
                     // Copy file path
                     results.Add(new Result
                     {
@@ -777,23 +779,26 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                         }
                     });
 
-                    // Copy file content
                     if (filePaths.Length == 1)
                     {
-                        results.Add(new Result
+                        if (existingFilePaths.Length == 1)
                         {
-                            Title = Localize.flowlauncher_plugin_clipboardplus_copy_file_content_title(),
-                            SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_file_content_subtitle(),
-                            IcoPath = PathHelper.CopyIconPath,
-                            Glyph = ResourceHelper.CopyGlyph,
-                            Score = ScoreInterval10,
-                            AddSelectedCount = false,
-                            Action = (c) =>
+                            // Copy file content
+                            results.Add(new Result
                             {
-                                CopyFileContentToClipboard(clipboardDataPair, filePaths);
-                                return true;
-                            }
-                        });
+                                Title = Localize.flowlauncher_plugin_clipboardplus_copy_file_content_title(),
+                                SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_file_content_subtitle(),
+                                IcoPath = PathHelper.CopyIconPath,
+                                Glyph = ResourceHelper.CopyGlyph,
+                                Score = ScoreInterval10,
+                                AddSelectedCount = false,
+                                Action = (c) =>
+                                {
+                                    CopyFileContentToClipboard(clipboardDataPair, existingFilePaths);
+                                    return true;
+                                }
+                            });
+                        }
                     }
                     // Copy file by sorting paths
                     else
@@ -1844,7 +1849,8 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                     case DefaultFilesCopyOption.Content:
                         var validObject1 = clipboardData.DataToValid();
                         var filePaths1 = (validObject1 as string[])!;
-                        if (filePaths1.Length == 1)
+                        var existingFilePaths = filePaths1.Where(FileUtils.Exists).ToArray();
+                        if (filePaths1.Length == 1 && existingFilePaths.Length == 1)
                         {
                             CopyFileContentToClipboard(clipboardDataPair, filePaths1);
                         }

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
@@ -742,8 +742,7 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                     }
                 });
 
-                var validObject = clipboardData.DataToValid();
-                if (validObject is string[] filePaths)
+                if (clipboardData.Data is string[] filePaths)
                 {
                     var existingFilePaths = filePaths.Where(FileUtils.Exists).ToArray();
 
@@ -1836,8 +1835,7 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                         CopyOriginallyToClipboard(clipboardDataPair);
                         break;
                     case DefaultFilesCopyOption.Path:
-                        var validObject = clipboardData.DataToValid();
-                        if (validObject is string[] filePaths)
+                        if (clipboardData.Data is string[] filePaths)
                         {
                             CopyFilePathToClipboard(clipboardDataPair, filePaths);
                         }
@@ -1847,12 +1845,17 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                         }
                         break;
                     case DefaultFilesCopyOption.Content:
-                        var validObject1 = clipboardData.DataToValid();
-                        var filePaths1 = (validObject1 as string[])!;
-                        var existingFilePaths = filePaths1.Where(FileUtils.Exists).ToArray();
-                        if (filePaths1.Length == 1 && existingFilePaths.Length == 1)
+                        if (clipboardData.Data is string[] filePaths1)
                         {
-                            CopyFileContentToClipboard(clipboardDataPair, filePaths1);
+                            var existingFilePaths = filePaths1.Where(FileUtils.Exists).ToArray();
+                            if (filePaths1.Length == 1 && existingFilePaths.Length == 1)
+                            {
+                                CopyFileContentToClipboard(clipboardDataPair, filePaths1);
+                            }
+                            else
+                            {
+                                CopyOriginallyToClipboard(clipboardDataPair);
+                            }
                         }
                         else
                         {
@@ -1860,8 +1863,7 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                         }
                         break;
                     case DefaultFilesCopyOption.FileName:
-                        var validObject2 = clipboardData.DataToValid();
-                        if (validObject2 is string[] filePaths2)
+                        if (clipboardData.Data is string[] filePaths2)
                         {
                             CopyFileNamesToClipboard(clipboardDataPair, filePaths2);
                         }
@@ -2075,12 +2077,11 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
             return;
         }
 
-        var validObject = clipboardData.DataToValid();
-        if (validObject is not null)
+        if (clipboardData.Data is string[] filePaths)
         {
-            var filePaths = ascend ? SortAscending((string[])validObject) : SortDescending((string[])validObject);
+            var sortedFilePaths = ascend ? SortAscending(filePaths) : SortDescending(filePaths);
             var paths = new StringCollection();
-            paths.AddRange(filePaths);
+            paths.AddRange(sortedFilePaths);
             var exception = await RetryActionOnSTAThreadAsync(() =>
             {
                 Clipboard.SetFileDropList(paths);
@@ -2091,7 +2092,7 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                 {
                     Context.ShowMsg(Localize.flowlauncher_plugin_clipboardplus_success(),
                         Localize.flowlauncher_plugin_clipboardplus_copy_to_clipboard() +
-                        StringUtils.CompressString(clipboardData.GetText(CultureInfo, validObject as string[]), StringMaxLength));
+                        StringUtils.CompressString(clipboardData.GetText(CultureInfo, filePaths), StringMaxLength));
                 }
             }
             else
@@ -2126,14 +2127,14 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
             return;
         }
 
-        if (clipboardData.DataToValid() is not string[] validFilePaths)
+        if (clipboardData.Data is not string[] filePaths)
         {
             Context.ShowMsgError(Localize.flowlauncher_plugin_clipboardplus_fail(),
                 Localize.flowlauncher_plugin_clipboardplus_files_data_invalid());
             return;
         }
 
-        var sortedFilePaths = ascend ? SortAscending(validFilePaths) : SortDescending(validFilePaths);
+        var sortedFilePaths = ascend ? SortAscending(filePaths) : SortDescending(filePaths);
         CopyFileNamesToClipboard(clipboardDataPair, sortedFilePaths);
     }
 
@@ -2176,14 +2177,14 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
             return;
         }
 
-        if (clipboardData.DataToValid() is not string[] validFilePaths)
+        if (clipboardData.Data is not string[] filePaths)
         {
             Context.ShowMsgError(Localize.flowlauncher_plugin_clipboardplus_fail(),
                 Localize.flowlauncher_plugin_clipboardplus_files_data_invalid());
             return;
         }
 
-        var sortedFilePaths = ascend ? SortAscending(validFilePaths) : SortDescending(validFilePaths);
+        var sortedFilePaths = ascend ? SortAscending(filePaths) : SortDescending(filePaths);
         CopyFilePathToClipboard(clipboardDataPair, sortedFilePaths);
     }
 

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
@@ -778,29 +778,27 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                         }
                     });
 
-                    if (filePaths.Length == 1)
+                    // Copy file content
+                    if (filePaths.Length == 1 && existingFilePaths.Length == 1)
                     {
-                        if (existingFilePaths.Length == 1)
+                        results.Add(new Result
                         {
-                            // Copy file content
-                            results.Add(new Result
+                            Title = Localize.flowlauncher_plugin_clipboardplus_copy_file_content_title(),
+                            SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_file_content_subtitle(),
+                            IcoPath = PathHelper.CopyIconPath,
+                            Glyph = ResourceHelper.CopyGlyph,
+                            Score = ScoreInterval10,
+                            AddSelectedCount = false,
+                            Action = (c) =>
                             {
-                                Title = Localize.flowlauncher_plugin_clipboardplus_copy_file_content_title(),
-                                SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_file_content_subtitle(),
-                                IcoPath = PathHelper.CopyIconPath,
-                                Glyph = ResourceHelper.CopyGlyph,
-                                Score = ScoreInterval10,
-                                AddSelectedCount = false,
-                                Action = (c) =>
-                                {
-                                    CopyFileContentToClipboard(clipboardDataPair, existingFilePaths);
-                                    return true;
-                                }
-                            });
-                        }
+                                CopyFileContentToClipboard(clipboardDataPair, existingFilePaths);
+                                return true;
+                            }
+                        });
                     }
+
                     // Copy file by sorting paths
-                    else
+                    if (filePaths.Length > 1)
                     {
                         results.AddRange(
                         [

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
@@ -2140,8 +2140,7 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
     private async void CopyFileNamesToClipboard(ClipboardDataPair _, string[] filePaths)
     {
         var fileNames = filePaths
-            .Select(p => Path.GetFileName(Path.TrimEndingDirectorySeparator(p)))
-            .Where(name => !string.IsNullOrEmpty(name));
+            .Select(FileUtils.GetPathName);
         var text = string.Join(Environment.NewLine, fileNames);
 
         if (string.IsNullOrEmpty(text))

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
@@ -102,6 +102,7 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
     private const int ScoreInterval11 = 11 * ScoreInterval;
     private const int ScoreInterval12 = 12 * ScoreInterval;
     private const int ScoreInterval13 = 13 * ScoreInterval;
+    private const int ScoreInterval14 = 14 * ScoreInterval;
 
     private const int TopActionScore1 = 2 * ClipboardData.MaximumScore + 4 * ScoreInterval;
     private const int TopActionScore2 = 2 * ClipboardData.MaximumScore + 3 * ScoreInterval;
@@ -626,7 +627,7 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                     SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_subtitle(),
                     IcoPath = PathHelper.CopyIconPath,
                     Glyph = ResourceHelper.CopyGlyph,
-                    Score = ScoreInterval13,
+                    Score = ScoreInterval14,
                     AddSelectedCount = false,
                     Action = (c) =>
                     {
@@ -732,7 +733,7 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                     SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_files_subtitle(),
                     IcoPath = PathHelper.CopyIconPath,
                     Glyph = ResourceHelper.CopyGlyph,
-                    Score = ScoreInterval12,
+                    Score = ScoreInterval13,
                     AddSelectedCount = false,
                     Action = (c) =>
                     {
@@ -751,11 +752,27 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                         SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_file_path_subtitle(),
                         IcoPath = PathHelper.CopyIconPath,
                         Glyph = ResourceHelper.CopyGlyph,
-                        Score = ScoreInterval11,
+                        Score = ScoreInterval12,
                         AddSelectedCount = false,
                         Action = (c) =>
                         {
                             CopyFilePathToClipboard(clipboardDataPair, filePaths);
+                            return true;
+                        }
+                    });
+
+                    // Copy file name
+                    results.Add(new Result
+                    {
+                        Title = Localize.flowlauncher_plugin_clipboardplus_copy_file_name_title(),
+                        SubTitle = Localize.flowlauncher_plugin_clipboardplus_copy_file_name_subtitle(),
+                        IcoPath = PathHelper.CopyIconPath,
+                        Glyph = ResourceHelper.CopyGlyph,
+                        Score = ScoreInterval11,
+                        AddSelectedCount = false,
+                        Action = (c) =>
+                        {
+                            CopyFileNamesToClipboard(clipboardDataPair, filePaths);
                             return true;
                         }
                     });
@@ -1836,6 +1853,17 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
                             CopyOriginallyToClipboard(clipboardDataPair);
                         }
                         break;
+                    case DefaultFilesCopyOption.FileName:
+                        var validObject2 = clipboardData.DataToValid();
+                        if (validObject2 is string[] filePaths2)
+                        {
+                            CopyFileNamesToClipboard(clipboardDataPair, filePaths2);
+                        }
+                        else
+                        {
+                            CopyOriginallyToClipboard(clipboardDataPair);
+                        }
+                        break;
                     case DefaultFilesCopyOption.NameAsc:
                         CopyBySortingNameToClipboard(clipboardDataPair, true);
                         break;
@@ -2084,7 +2112,7 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
         return [.. strings.OrderByDescending(path => path, new NaturalStringComparer())];
     }
 
-    private async void CopyFileNamesBySortingPathToClipboard(ClipboardDataPair clipboardDataPair, bool ascend)
+    private void CopyFileNamesBySortingPathToClipboard(ClipboardDataPair clipboardDataPair, bool ascend)
     {
         var clipboardData = clipboardDataPair.ClipboardData;
         if (clipboardData.DataType != DataType.Files)
@@ -2100,10 +2128,23 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
         }
 
         var sortedFilePaths = ascend ? SortAscending(validFilePaths) : SortDescending(validFilePaths);
-        var fileNames = sortedFilePaths
+        CopyFileNamesToClipboard(clipboardDataPair, sortedFilePaths);
+    }
+
+    private async void CopyFileNamesToClipboard(ClipboardDataPair clipboardDataPair, string[] filePaths)
+    {
+        var fileNames = filePaths
             .Select(p => Path.GetFileName(Path.TrimEndingDirectorySeparator(p)))
             .Where(name => !string.IsNullOrEmpty(name));
         var text = string.Join(Environment.NewLine, fileNames);
+
+        if (string.IsNullOrEmpty(text))
+        {
+            Context.ShowMsgError(Localize.flowlauncher_plugin_clipboardplus_fail(),
+                Localize.flowlauncher_plugin_clipboardplus_files_data_invalid());
+            return;
+        }
+
         var exception = await RetryActionOnSTAThreadAsync(() => Clipboard.SetText(text));
         if (exception == null)
         {

--- a/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
+++ b/src/Flow.Launcher.Plugin.ClipboardPlus/Main.cs
@@ -2137,7 +2137,7 @@ public class ClipboardPlus : IAsyncPlugin, IAsyncReloadable, IContextMenu, IPlug
         CopyFileNamesToClipboard(clipboardDataPair, sortedFilePaths);
     }
 
-    private async void CopyFileNamesToClipboard(ClipboardDataPair clipboardDataPair, string[] filePaths)
+    private async void CopyFileNamesToClipboard(ClipboardDataPair _, string[] filePaths)
     {
         var fileNames = filePaths
             .Select(p => Path.GetFileName(Path.TrimEndingDirectorySeparator(p)))


### PR DESCRIPTION
Added a context menu option to copy only file names (no directories) for selected files. Updated DefaultFilesCopyOption enum and localization files for new option. Adjusted menu item scores for correct ordering. Implemented CopyFileNamesToClipboard method and integrated new option into main plugin logic.